### PR TITLE
Move over zealous check for target profile into processing of the roo…

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -59,6 +59,14 @@ func init() {
 //noinspection GoUnusedParameter
 func rootCmdFunction(cmd *cobra.Command, args []string) {
 	log.Info("Starting")
+
+	if len(config.SessionProfile) == 0 {
+		_, _ = fmt.Fprintf(os.Stderr,
+			"I do not know the name of the profile to update or create.\n"+
+				"Try setting profile or session-profile\n")
+		os.Exit(1)
+	}
+
 	identity := getIdentity()
 
 	arn := identity.Arn
@@ -69,35 +77,36 @@ func rootCmdFunction(cmd *cobra.Command, args []string) {
 
 	token := getSessionToken(sn, mfa)
 
-	if len(config.TargetProfile) == 0 {
-		panic("Target Profile should be set")
+	if len(config.SessionProfile) == 0 {
+		panic("Session Profile should be set")
 	}
 
-	setAccessKeyId(config.TargetProfile, *token.Credentials.AccessKeyId)
-	setSecretAccessKey(config.TargetProfile, *token.Credentials.SecretAccessKey)
-	setSessionToken(config.TargetProfile, *token.Credentials.SessionToken)
+	setAccessKeyId(config.SessionProfile, *token.Credentials.AccessKeyId)
+	setSecretAccessKey(config.SessionProfile, *token.Credentials.SecretAccessKey)
+	setSessionToken(config.SessionProfile, *token.Credentials.SessionToken)
 
+	_, _ = fmt.Fprintf(os.Stdout, "%s profile updated\n", config.SessionProfile)
 	log.Info("Done")
 }
 
-func setSessionToken(targetProfile string, sessionToken string) {
-	cmd := exec.Command("aws", "configure", "--profile", targetProfile, "set", "aws_session_token", sessionToken)
+func setSessionToken(sessionProfile string, sessionToken string) {
+	cmd := exec.Command("aws", "configure", "--profile", sessionProfile, "set", "aws_session_token", sessionToken)
 	err := cmd.Run()
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Failed to set session token: %s\n", err)
 	}
 }
 
-func setSecretAccessKey(targetProfile string, secretAccessKey string) {
-	cmd := exec.Command("aws", "configure", "--profile", targetProfile, "set", "aws_secret_access_key", secretAccessKey)
+func setSecretAccessKey(sessionProfile string, secretAccessKey string) {
+	cmd := exec.Command("aws", "configure", "--profile", sessionProfile, "set", "aws_secret_access_key", secretAccessKey)
 	err := cmd.Run()
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Failed to set session token: %s\n", err)
 	}
 }
 
-func setAccessKeyId(targetProfile string, accessKeyId string) {
-	cmd := exec.Command("aws", "configure", "--profile", targetProfile, "set", "aws_access_key_id", accessKeyId)
+func setAccessKeyId(sessionProfile string, accessKeyId string) {
+	cmd := exec.Command("aws", "configure", "--profile", sessionProfile, "set", "aws_access_key_id", accessKeyId)
 	err := cmd.Run()
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Failed to set session token: %s\n", err)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -12,8 +12,8 @@ func init() {
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "Print the version number of Hugo",
-	Long:  `All software has versions. This is Hugo's`,
+	Short: "Print the version number of mfaws",
+	Long:  `All software has versions. This is mfaws's`,
 	Run:   versionCmdFunc,
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -54,7 +54,7 @@ func processConfig() {
 	professLoggingLevel()
 	processProfile()
 	processRegion()
-	processTargetProfile()
+	processSessionProfile()
 }
 
 func logSetEnvError(key string, err error) {
@@ -82,23 +82,22 @@ func processRegion() {
 	}
 }
 
-var TargetProfile string
+var SessionProfile string
 
-func processTargetProfile() {
-	TargetProfile = viper.GetString("aws.target_profile")
-	if len(TargetProfile) == 0 {
+func processSessionProfile() {
+	SessionProfile = viper.GetString("aws.session.profile")
+	if len(SessionProfile) == 0 {
 		profile := os.Getenv("AWS_PROFILE")
 		if len(profile) > 0 {
-			TargetProfile = profile + "_session"
+			SessionProfile = profile + "_session"
 		}
 	}
 
-	if len(TargetProfile) == 0 {
-		_, _ = fmt.Fprintf(os.Stderr, "Neither profile nor target profile set\n")
-		os.Exit(1)
+	if len(SessionProfile) == 0 {
+		log.Warnf("Neither profile nor session profile set\n")
+	} else {
+		log.Infof("Session profile %s", SessionProfile)
 	}
-
-	log.Infof("Targeting profile %s", TargetProfile)
 }
 
 func professLoggingLevel() {


### PR DESCRIPTION
…t command instead of config.

Changes reference to Target Profile to Session Profile for consistency with flags.
Fix a big causing viper to fail to read command line flag for session_profile.
Corrected name of command in versionCmd.